### PR TITLE
Updated README and added go.mod file to support go versions beyond 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Connect two Go (game) engines via [Go Text Protocol](https://www.lysator.liu.se/
 
 # Building
 
-* `go get github.com/rooklift/sgf`
+* `go mod download github.com/rooklift/sgf`
 * `go build twogtp.go`
 
 # Features

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/rooklift/twogtp
+
+require github.com/rooklift/sgf master
+
+go 1.16


### PR DESCRIPTION
Reference: https://go.dev/doc/go-get-install-deprecation

The tag is a little awkward and using the `mod download` command actually changes the go.mod file to have a weird autogenerated version/hash thing.  So it might be better to just create a tag on rooklift/sgf

This is my first contribution for any go project, and I don't know if I did this the right way, so if not please let me know.